### PR TITLE
feat: Google Places API連携 - スクレイピング＆口コミ統合

### DIFF
--- a/.claude/commands/scrape-salons.md
+++ b/.claude/commands/scrape-salons.md
@@ -1,0 +1,53 @@
+# サロンスクレイピング＆レビュー更新
+
+Google Places APIを使ってトリミングサロンを収集し、DBに登録するスキル。
+
+## 使い方
+`/scrape-salons [オプション]`
+
+## 前提条件
+- `.env.local` に `GOOGLE_PLACES_API_KEY` が設定されていること
+- Google Cloud Console で Places API (New) が有効であること
+- Supabase に `20240103000000_google_places.sql` マイグレーションが適用済みであること
+
+## 実行手順
+
+### Step 1: 環境確認
+- `.env.local` の `GOOGLE_PLACES_API_KEY` 存在確認
+- Supabase接続テスト（prefecturesテーブル読み取り）
+
+### Step 2: サロンスクレイピング
+```bash
+# 全都道府県（時間がかかる）
+npx tsx --env-file=.env.local scripts/scrape-google-places.ts
+
+# 特定都道府県のみ（推奨）
+npx tsx --env-file=.env.local scripts/scrape-google-places.ts --prefecture tokyo
+
+# ドライラン（DB書き込みなし、API確認用）
+npx tsx --env-file=.env.local scripts/scrape-google-places.ts --dry-run
+```
+
+### Step 3: レビュー更新
+```bash
+# 全サロンのレビュー更新
+npx tsx --env-file=.env.local scripts/fetch-google-reviews.ts
+
+# 7日以上未更新のサロンのみ（上限50件）
+npx tsx --env-file=.env.local scripts/fetch-google-reviews.ts --stale-days 7 --limit 50
+```
+
+### Step 4: 確認
+- Supabaseダッシュボードで salons テーブルの `google_place_id` 有無を確認
+- `external_reviews` テーブルにレビューが登録されていることを確認
+- `npm run dev` でサロン詳細ページにGoogle口コミが表示されることを確認
+
+## 定期実行の推奨フロー
+1. 週1回: `--stale-days 7` でレビュー更新
+2. 月1回: 新規サロン検索（都道府県を分割して実行）
+3. API使用量をGoogle Cloud Consoleで監視
+
+## API料金目安
+- Text Search: $32 / 1,000リクエスト
+- Place Details: $17 / 1,000リクエスト
+- 無料枠: 月$200相当のクレジット（Maps Platform）

--- a/scripts/fetch-google-reviews.ts
+++ b/scripts/fetch-google-reviews.ts
@@ -1,0 +1,418 @@
+/**
+ * 既存サロンの Google レビュー更新スクリプト
+ *
+ * google_place_id が設定されているサロンに対して、
+ * Place Details API でレビューを取得し external_reviews テーブルに upsert する。
+ * 同時にサロンの google_rating / google_review_count も更新する。
+ *
+ * 使い方:
+ *   # 全サロンのレビューを更新
+ *   npx tsx --env-file=.env.local scripts/fetch-google-reviews.ts
+ *
+ *   # 最終スクレイピングから7日以上経過したサロンのみ
+ *   npx tsx --env-file=.env.local scripts/fetch-google-reviews.ts --stale-days 7
+ *
+ *   # ドライラン
+ *   npx tsx --env-file=.env.local scripts/fetch-google-reviews.ts --dry-run
+ *
+ *   # 処理するサロン数を制限
+ *   npx tsx --env-file=.env.local scripts/fetch-google-reviews.ts --limit 50
+ *
+ * 必要な環境変数(.env.local):
+ *   NEXT_PUBLIC_SUPABASE_URL      - Supabase プロジェクトURL
+ *   SUPABASE_SERVICE_ROLE_KEY     - Supabase Service Role Key (RLSバイパス)
+ *   GOOGLE_PLACES_API_KEY         - Google Places API (New) キー
+ *
+ * 環境変数の読み込みについて:
+ *   npx tsx はデフォルトでは .env.local を読み込みません。
+ *   --env-file=.env.local オプションを付けるか、
+ *   dotenv パッケージ経由で読み込んでください（このスクリプトでは dotenv/config も呼んでいます）。
+ */
+
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { config } from 'dotenv';
+import { resolve } from 'path';
+import {
+  GooglePlacesClient,
+  PlaceReview,
+  getReviewId,
+  ApiQuotaExceededError,
+} from './lib/google-places';
+
+// .env.local から環境変数を読み込む（--env-file を使わない場合のフォールバック）
+config({ path: resolve(__dirname, '..', '.env.local') });
+
+// ========================================
+// 環境変数チェック
+// ========================================
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const GOOGLE_API_KEY = process.env.GOOGLE_PLACES_API_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
+  console.error('エラー: Supabase の環境変数が設定されていません。');
+  console.error('NEXT_PUBLIC_SUPABASE_URL と SUPABASE_SERVICE_ROLE_KEY を .env.local に設定してください。');
+  process.exit(1);
+}
+
+if (!GOOGLE_API_KEY) {
+  console.error('エラー: GOOGLE_PLACES_API_KEY が設定されていません。');
+  console.error('');
+  console.error('Google Cloud Console で API キーを取得してください:');
+  console.error('  1. https://console.cloud.google.com/apis/credentials で API キーを作成');
+  console.error('  2. Places API (New) を有効化');
+  console.error('  3. .env.local に追加: GOOGLE_PLACES_API_KEY=your_api_key_here');
+  process.exit(1);
+}
+
+// ========================================
+// クライアント初期化
+// ========================================
+
+const supabase: SupabaseClient = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY, {
+  auth: {
+    autoRefreshToken: false,
+    persistSession: false,
+  },
+});
+
+const placesClient = new GooglePlacesClient(GOOGLE_API_KEY, {
+  requestsPerSecond: 1,
+  maxRetries: 3,
+});
+
+// ========================================
+// コマンドライン引数解析
+// ========================================
+
+interface CliOptions {
+  dryRun: boolean;
+  staleDays: number;  // この日数以上 last_scraped_at が古いサロンのみ対象
+  limit: number;      // 処理するサロン数の上限（0 = 無制限）
+}
+
+function parseArgs(): CliOptions {
+  const args = process.argv.slice(2);
+  const options: CliOptions = {
+    dryRun: false,
+    staleDays: 0,
+    limit: 0,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--dry-run') {
+      options.dryRun = true;
+    } else if (args[i] === '--stale-days' && i + 1 < args.length) {
+      options.staleDays = parseInt(args[i + 1], 10);
+      if (isNaN(options.staleDays) || options.staleDays < 0) {
+        console.error('エラー: --stale-days は 0 以上の整数を指定してください');
+        process.exit(1);
+      }
+      i++;
+    } else if (args[i] === '--limit' && i + 1 < args.length) {
+      options.limit = parseInt(args[i + 1], 10);
+      if (isNaN(options.limit) || options.limit < 1) {
+        console.error('エラー: --limit は 1 以上の整数を指定してください');
+        process.exit(1);
+      }
+      i++;
+    } else if (args[i] === '--help' || args[i] === '-h') {
+      console.log('使い方:');
+      console.log('  npx tsx --env-file=.env.local scripts/fetch-google-reviews.ts [オプション]');
+      console.log('');
+      console.log('オプション:');
+      console.log('  --stale-days <N>  N日以上更新されていないサロンのみ対象 (デフォルト: 0=全て)');
+      console.log('  --limit <N>       処理するサロン数を制限');
+      console.log('  --dry-run         DB書き込みなしの確認モード');
+      console.log('  --help, -h        このヘルプを表示');
+      process.exit(0);
+    }
+  }
+
+  return options;
+}
+
+// ========================================
+// 型定義
+// ========================================
+
+interface SalonWithGoogleId {
+  id: string;
+  name: string;
+  google_place_id: string;
+  last_scraped_at: string | null;
+}
+
+interface ReviewStats {
+  totalSalons: number;
+  processed: number;
+  reviewsInserted: number;
+  reviewsUpdated: number;
+  failed: number;
+  skipped: number;
+}
+
+// ========================================
+// メイン処理
+// ========================================
+
+/**
+ * google_place_id が設定されているサロン一覧を取得する
+ */
+async function fetchSalonsWithGoogleId(options: CliOptions): Promise<SalonWithGoogleId[]> {
+  let query = supabase
+    .from('salons')
+    .select('id, name, google_place_id, last_scraped_at')
+    .not('google_place_id', 'is', null)
+    .order('last_scraped_at', { ascending: true, nullsFirst: true });
+
+  // stale-days フィルタ
+  if (options.staleDays > 0) {
+    const staleDate = new Date();
+    staleDate.setDate(staleDate.getDate() - options.staleDays);
+    query = query.or(`last_scraped_at.is.null,last_scraped_at.lt.${staleDate.toISOString()}`);
+  }
+
+  // limit
+  if (options.limit > 0) {
+    query = query.limit(options.limit);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    throw new Error(`サロン一覧の取得に失敗: ${error.message}`);
+  }
+
+  return (data || []) as SalonWithGoogleId[];
+}
+
+/**
+ * 1件のサロンのレビューを取得・更新する
+ */
+async function updateSalonReviews(
+  salon: SalonWithGoogleId,
+  dryRun: boolean,
+  stats: ReviewStats
+): Promise<void> {
+  try {
+    // Place Details API でレビューを取得
+    const placeDetails = await placesClient.getPlaceReviews(salon.google_place_id);
+
+    // google_rating / google_review_count を更新
+    const ratingUpdate = {
+      google_rating: placeDetails.rating ?? null,
+      google_review_count: placeDetails.userRatingCount ?? 0,
+      last_scraped_at: new Date().toISOString(),
+    };
+
+    if (!dryRun) {
+      const { error: updateError } = await supabase
+        .from('salons')
+        .update(ratingUpdate)
+        .eq('id', salon.id);
+
+      if (updateError) {
+        console.error(`    評価更新エラー: ${updateError.message}`);
+      }
+    } else {
+      console.log(`    [DRY RUN] 評価更新: ${placeDetails.rating ?? 'N/A'} (${placeDetails.userRatingCount ?? 0}件)`);
+    }
+
+    // レビューを upsert
+    const reviews = placeDetails.reviews;
+    if (!reviews || reviews.length === 0) {
+      console.log(`    レビュー: 0 件`);
+      return;
+    }
+
+    console.log(`    レビュー: ${reviews.length} 件`);
+
+    for (const review of reviews) {
+      await upsertSingleReview(salon.id, review, dryRun, stats);
+    }
+  } catch (error) {
+    if (error instanceof ApiQuotaExceededError) {
+      throw error;
+    }
+    console.error(`    エラー: ${error}`);
+    stats.failed++;
+  }
+}
+
+/**
+ * 1件のレビューを external_reviews テーブルに upsert する
+ */
+async function upsertSingleReview(
+  salonId: string,
+  review: PlaceReview,
+  dryRun: boolean,
+  stats: ReviewStats
+): Promise<void> {
+  const sourceReviewId = getReviewId(review);
+  const rating = Math.min(5, Math.max(1, Math.round(review.rating)));
+
+  const reviewData = {
+    salon_id: salonId,
+    source: 'google' as const,
+    source_review_id: sourceReviewId,
+    author_name: review.authorAttribution?.displayName ?? '匿名',
+    author_photo_url: review.authorAttribution?.photoUri ?? null,
+    rating,
+    text: review.text?.text ?? review.originalText?.text ?? null,
+    published_at: review.publishTime ?? null,
+    language: review.text?.languageCode ?? review.originalText?.languageCode ?? 'ja',
+  };
+
+  if (dryRun) {
+    console.log(`      [DRY RUN] レビュー: ${reviewData.author_name} (${rating}点)`);
+    stats.reviewsInserted++;
+    return;
+  }
+
+  // 既存チェック
+  const { data: existing } = await supabase
+    .from('external_reviews')
+    .select('id')
+    .eq('source', 'google')
+    .eq('source_review_id', sourceReviewId)
+    .maybeSingle();
+
+  if (existing) {
+    // UPDATE
+    const { error } = await supabase
+      .from('external_reviews')
+      .update({
+        rating: reviewData.rating,
+        text: reviewData.text,
+        author_name: reviewData.author_name,
+        author_photo_url: reviewData.author_photo_url,
+      })
+      .eq('id', existing.id);
+
+    if (error) {
+      console.warn(`      レビュー更新エラー: ${error.message}`);
+      stats.failed++;
+    } else {
+      stats.reviewsUpdated++;
+    }
+  } else {
+    // INSERT
+    const { error } = await supabase
+      .from('external_reviews')
+      .insert(reviewData);
+
+    if (error) {
+      if (error.code === '23505') {
+        // 重複（race condition）-> 無視
+        stats.skipped++;
+      } else {
+        console.warn(`      レビュー挿入エラー: ${error.message}`);
+        stats.failed++;
+      }
+    } else {
+      stats.reviewsInserted++;
+    }
+  }
+}
+
+/**
+ * メイン関数
+ */
+async function main(): Promise<void> {
+  const options = parseArgs();
+
+  console.log('========================================');
+  console.log('Google レビュー更新スクリプト');
+  console.log('========================================');
+  if (options.dryRun) {
+    console.log('[DRY RUN モード] DB書き込みは行いません');
+  }
+  if (options.staleDays > 0) {
+    console.log(`対象: 最終スクレイピングから ${options.staleDays} 日以上経過したサロン`);
+  }
+  if (options.limit > 0) {
+    console.log(`処理上限: ${options.limit} 件`);
+  }
+  console.log('');
+
+  // Ctrl+C ハンドリング
+  let interrupted = false;
+  process.on('SIGINT', () => {
+    console.log('\n\n中断されました。現在の進捗までの結果を表示します...');
+    interrupted = true;
+  });
+
+  const stats: ReviewStats = {
+    totalSalons: 0,
+    processed: 0,
+    reviewsInserted: 0,
+    reviewsUpdated: 0,
+    failed: 0,
+    skipped: 0,
+  };
+
+  try {
+    // google_place_id が設定されているサロン一覧を取得
+    const salons = await fetchSalonsWithGoogleId(options);
+    stats.totalSalons = salons.length;
+
+    if (salons.length === 0) {
+      console.log('対象サロンがありません。');
+      console.log('google_place_id が設定されたサロンが必要です。');
+      console.log('先に scrape-google-places.ts を実行してサロンデータを取得してください。');
+      return;
+    }
+
+    console.log(`対象サロン: ${salons.length} 件`);
+    console.log('');
+
+    // 各サロンのレビューを更新
+    for (let i = 0; i < salons.length; i++) {
+      if (interrupted) break;
+
+      const salon = salons[i];
+      console.log(`[${i + 1}/${salons.length}] ${salon.name}`);
+
+      await updateSalonReviews(salon, options.dryRun, stats);
+      stats.processed++;
+    }
+  } catch (error) {
+    if (error instanceof ApiQuotaExceededError) {
+      console.error('');
+      console.error('=== API Quota 超過 ===');
+      console.error('Google Places API の利用制限に達しました。');
+      console.error('しばらく待ってから再実行してください。');
+      console.error('既に更新済みのデータは保持されています。');
+    } else {
+      console.error(`\n予期しないエラー: ${error}`);
+    }
+  }
+
+  // 結果サマリー
+  console.log('');
+  console.log('========================================');
+  console.log('レビュー更新結果サマリー');
+  if (options.dryRun) {
+    console.log('[DRY RUN モード]');
+  }
+  console.log('========================================');
+  console.log(`  対象サロン数:     ${stats.totalSalons} 件`);
+  console.log(`  処理完了:         ${stats.processed} 件`);
+  console.log('  ---');
+  console.log(`  レビュー新規登録: ${stats.reviewsInserted} 件`);
+  console.log(`  レビュー更新:     ${stats.reviewsUpdated} 件`);
+  console.log(`  スキップ(重複):   ${stats.skipped} 件`);
+  console.log(`  失敗:             ${stats.failed} 件`);
+  console.log('========================================');
+}
+
+// ========================================
+// エントリポイント
+// ========================================
+
+main().catch((err) => {
+  console.error('予期しないエラーが発生しました:', err);
+  process.exit(1);
+});

--- a/scripts/lib/google-places.ts
+++ b/scripts/lib/google-places.ts
@@ -1,0 +1,507 @@
+/**
+ * Google Places API (New) ラッパーモジュール
+ *
+ * Text Search API / Place Details API を使ってトリミングサロン情報を取得する。
+ * Rate limiting、リトライ、型定義を含む。
+ *
+ * 必要な環境変数:
+ *   GOOGLE_PLACES_API_KEY
+ *
+ * 参考:
+ *   https://developers.google.com/maps/documentation/places/web-service/text-search
+ *   https://developers.google.com/maps/documentation/places/web-service/place-details
+ */
+
+// ========================================
+// Google Places API レスポンス型定義
+// ========================================
+
+/** 場所の座標 */
+export interface LatLng {
+  latitude: number;
+  longitude: number;
+}
+
+/** 表示名 */
+export interface DisplayName {
+  text: string;
+  languageCode: string;
+}
+
+/** 営業時間の期間 */
+export interface OpeningHoursPeriod {
+  open: {
+    day: number; // 0=日 ~ 6=土
+    hour: number;
+    minute: number;
+  };
+  close: {
+    day: number;
+    hour: number;
+    minute: number;
+  };
+}
+
+/** 営業時間 */
+export interface RegularOpeningHours {
+  openNow?: boolean;
+  periods?: OpeningHoursPeriod[];
+  weekdayDescriptions?: string[];
+}
+
+/** 写真リファレンス */
+export interface PlacePhoto {
+  name: string; // "places/{place_id}/photos/{photo_reference}"
+  widthPx: number;
+  heightPx: number;
+  authorAttributions: Array<{
+    displayName: string;
+    uri: string;
+    photoUri: string;
+  }>;
+}
+
+/** レビュー著者の属性 */
+export interface AuthorAttribution {
+  displayName: string;
+  uri: string;
+  photoUri: string;
+}
+
+/** レビュー */
+export interface PlaceReview {
+  name: string; // レビューのリソース名
+  relativePublishTimeDescription: string;
+  rating: number;
+  text?: {
+    text: string;
+    languageCode: string;
+  };
+  originalText?: {
+    text: string;
+    languageCode: string;
+  };
+  authorAttribution: AuthorAttribution;
+  publishTime: string; // ISO 8601
+}
+
+/** Place オブジェクト（Text Search / Place Details 共通） */
+export interface GooglePlace {
+  id: string; // Place ID (例: "ChIJ...")
+  displayName: DisplayName;
+  formattedAddress?: string;
+  location?: LatLng;
+  nationalPhoneNumber?: string;
+  internationalPhoneNumber?: string;
+  websiteUri?: string;
+  regularOpeningHours?: RegularOpeningHours;
+  rating?: number;
+  userRatingCount?: number;
+  photos?: PlacePhoto[];
+  reviews?: PlaceReview[];
+  types?: string[];
+  businessStatus?: string;
+  googleMapsUri?: string;
+}
+
+/** Text Search API レスポンス */
+export interface TextSearchResponse {
+  places?: GooglePlace[];
+  nextPageToken?: string;
+}
+
+/** Place Details API レスポンス */
+export type PlaceDetailsResponse = GooglePlace;
+
+// ========================================
+// Rate Limiter
+// ========================================
+
+class RateLimiter {
+  private lastRequestTime = 0;
+  private readonly minIntervalMs: number;
+
+  constructor(requestsPerSecond: number = 1) {
+    this.minIntervalMs = 1000 / requestsPerSecond;
+  }
+
+  async wait(): Promise<void> {
+    const now = Date.now();
+    const elapsed = now - this.lastRequestTime;
+    if (elapsed < this.minIntervalMs) {
+      const waitTime = this.minIntervalMs - elapsed;
+      await new Promise((resolve) => setTimeout(resolve, waitTime));
+    }
+    this.lastRequestTime = Date.now();
+  }
+}
+
+// ========================================
+// エラークラス
+// ========================================
+
+export class GooglePlacesApiError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+    public readonly responseBody?: string
+  ) {
+    super(message);
+    this.name = 'GooglePlacesApiError';
+  }
+}
+
+export class ApiQuotaExceededError extends GooglePlacesApiError {
+  constructor(message: string, statusCode: number, responseBody?: string) {
+    super(message, statusCode, responseBody);
+    this.name = 'ApiQuotaExceededError';
+  }
+}
+
+// ========================================
+// Google Places API クライアント
+// ========================================
+
+/** Text Search のオプション */
+export interface SearchPlacesOptions {
+  /** 検索結果の最大件数（APIの上限は20） */
+  maxResultCount?: number;
+  /** ページトークン（次ページ取得用） */
+  pageToken?: string;
+  /** 言語コード */
+  languageCode?: string;
+}
+
+/** Place Details のオプション */
+export interface GetPlaceDetailsOptions {
+  /** 取得するフィールド */
+  fieldMask?: string;
+  /** 言語コード */
+  languageCode?: string;
+}
+
+/** Text Search で使用する FieldMask（サロン情報向け） */
+const TEXT_SEARCH_FIELD_MASK = [
+  'places.id',
+  'places.displayName',
+  'places.formattedAddress',
+  'places.location',
+  'places.nationalPhoneNumber',
+  'places.websiteUri',
+  'places.regularOpeningHours',
+  'places.rating',
+  'places.userRatingCount',
+  'places.photos',
+  'places.reviews',
+  'places.types',
+  'places.businessStatus',
+  'places.googleMapsUri',
+  'nextPageToken',
+].join(',');
+
+/** Place Details で使用する FieldMask（レビュー取得向け） */
+const PLACE_DETAILS_FIELD_MASK = [
+  'id',
+  'displayName',
+  'formattedAddress',
+  'location',
+  'nationalPhoneNumber',
+  'websiteUri',
+  'regularOpeningHours',
+  'rating',
+  'userRatingCount',
+  'photos',
+  'reviews',
+  'types',
+  'businessStatus',
+].join(',');
+
+/** レビュー取得専用の FieldMask */
+const REVIEWS_ONLY_FIELD_MASK = [
+  'id',
+  'displayName',
+  'rating',
+  'userRatingCount',
+  'reviews',
+].join(',');
+
+export class GooglePlacesClient {
+  private readonly apiKey: string;
+  private readonly rateLimiter: RateLimiter;
+  private readonly maxRetries: number;
+
+  constructor(apiKey: string, options?: { requestsPerSecond?: number; maxRetries?: number }) {
+    this.apiKey = apiKey;
+    this.rateLimiter = new RateLimiter(options?.requestsPerSecond ?? 1);
+    this.maxRetries = options?.maxRetries ?? 3;
+  }
+
+  /**
+   * Text Search API でトリミングサロンを検索する
+   */
+  async searchPlaces(
+    query: string,
+    options?: SearchPlacesOptions
+  ): Promise<TextSearchResponse> {
+    await this.rateLimiter.wait();
+
+    const body: Record<string, unknown> = {
+      textQuery: query,
+      languageCode: options?.languageCode ?? 'ja',
+    };
+
+    if (options?.maxResultCount) {
+      body.maxResultCount = options.maxResultCount;
+    }
+
+    if (options?.pageToken) {
+      body.pageToken = options.pageToken;
+    }
+
+    const response = await this.fetchWithRetry(
+      'https://places.googleapis.com/v1/places:searchText',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Goog-Api-Key': this.apiKey,
+          'X-Goog-FieldMask': TEXT_SEARCH_FIELD_MASK,
+        },
+        body: JSON.stringify(body),
+      }
+    );
+
+    return response as TextSearchResponse;
+  }
+
+  /**
+   * Place Details API で場所の詳細を取得する
+   */
+  async getPlaceDetails(
+    placeId: string,
+    options?: GetPlaceDetailsOptions
+  ): Promise<PlaceDetailsResponse> {
+    await this.rateLimiter.wait();
+
+    const fieldMask = options?.fieldMask ?? PLACE_DETAILS_FIELD_MASK;
+    const languageCode = options?.languageCode ?? 'ja';
+
+    const response = await this.fetchWithRetry(
+      `https://places.googleapis.com/v1/places/${placeId}?languageCode=${languageCode}`,
+      {
+        method: 'GET',
+        headers: {
+          'X-Goog-Api-Key': this.apiKey,
+          'X-Goog-FieldMask': fieldMask,
+        },
+      }
+    );
+
+    return response as PlaceDetailsResponse;
+  }
+
+  /**
+   * Place Details API でレビューのみを取得する
+   */
+  async getPlaceReviews(placeId: string): Promise<PlaceDetailsResponse> {
+    return this.getPlaceDetails(placeId, {
+      fieldMask: REVIEWS_ONLY_FIELD_MASK,
+    });
+  }
+
+  /**
+   * Text Search API で全ページ分の結果を取得する
+   * nextPageToken が無くなるまで自動的にページネーション
+   */
+  async searchAllPlaces(
+    query: string,
+    options?: Omit<SearchPlacesOptions, 'pageToken'>
+  ): Promise<GooglePlace[]> {
+    const allPlaces: GooglePlace[] = [];
+    let pageToken: string | undefined;
+
+    do {
+      const response = await this.searchPlaces(query, {
+        ...options,
+        pageToken,
+      });
+
+      if (response.places) {
+        allPlaces.push(...response.places);
+      }
+
+      pageToken = response.nextPageToken;
+
+      // 次のページがある場合は少し待つ（Google推奨）
+      if (pageToken) {
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+      }
+    } while (pageToken);
+
+    return allPlaces;
+  }
+
+  // ========================================
+  // 内部メソッド
+  // ========================================
+
+  /**
+   * リトライ付き fetch
+   */
+  private async fetchWithRetry(
+    url: string,
+    init: RequestInit,
+    retryCount = 0
+  ): Promise<unknown> {
+    try {
+      const response = await fetch(url, init);
+
+      if (!response.ok) {
+        const body = await response.text();
+
+        // Quota 超過
+        if (response.status === 429) {
+          if (retryCount < this.maxRetries) {
+            const waitTime = Math.pow(2, retryCount + 1) * 1000; // 指数バックオフ
+            console.warn(
+              `[Google Places API] Quota exceeded. ${waitTime / 1000}秒後にリトライします... (${retryCount + 1}/${this.maxRetries})`
+            );
+            await new Promise((resolve) => setTimeout(resolve, waitTime));
+            return this.fetchWithRetry(url, init, retryCount + 1);
+          }
+          throw new ApiQuotaExceededError(
+            `API Quota exceeded after ${this.maxRetries} retries`,
+            response.status,
+            body
+          );
+        }
+
+        // サーバーエラー（500系）はリトライ
+        if (response.status >= 500 && retryCount < this.maxRetries) {
+          const waitTime = Math.pow(2, retryCount + 1) * 1000;
+          console.warn(
+            `[Google Places API] Server error (${response.status}). ${waitTime / 1000}秒後にリトライします... (${retryCount + 1}/${this.maxRetries})`
+          );
+          await new Promise((resolve) => setTimeout(resolve, waitTime));
+          return this.fetchWithRetry(url, init, retryCount + 1);
+        }
+
+        throw new GooglePlacesApiError(
+          `Google Places API error: ${response.status} ${response.statusText}`,
+          response.status,
+          body
+        );
+      }
+
+      return await response.json();
+    } catch (error) {
+      // ネットワークエラーのリトライ
+      if (
+        error instanceof TypeError &&
+        error.message.includes('fetch') &&
+        retryCount < this.maxRetries
+      ) {
+        const waitTime = Math.pow(2, retryCount + 1) * 1000;
+        console.warn(
+          `[Google Places API] Network error. ${waitTime / 1000}秒後にリトライします... (${retryCount + 1}/${this.maxRetries})`
+        );
+        await new Promise((resolve) => setTimeout(resolve, waitTime));
+        return this.fetchWithRetry(url, init, retryCount + 1);
+      }
+      throw error;
+    }
+  }
+}
+
+// ========================================
+// ヘルパー関数
+// ========================================
+
+/**
+ * 営業時間の配列をテキストに変換する
+ * 例: "月: 10:00-19:00\n火: 10:00-19:00\n..."
+ */
+export function formatOpeningHours(
+  openingHours: RegularOpeningHours | undefined
+): string | null {
+  if (!openingHours?.weekdayDescriptions) {
+    return null;
+  }
+  return openingHours.weekdayDescriptions.join('\n');
+}
+
+/**
+ * 営業時間から定休日を推定する
+ * weekdayDescriptions に "定休日" や "Closed" が含まれる曜日を抽出
+ */
+export function extractHolidays(
+  openingHours: RegularOpeningHours | undefined
+): string | null {
+  if (!openingHours?.weekdayDescriptions) {
+    return null;
+  }
+
+  const dayNames = ['月曜日', '火曜日', '水曜日', '木曜日', '金曜日', '土曜日', '日曜日'];
+  const closedDays: string[] = [];
+
+  for (const desc of openingHours.weekdayDescriptions) {
+    // "月曜日: 定休日" や "Monday: Closed" のパターンを検出
+    if (desc.includes('定休日') || desc.toLowerCase().includes('closed')) {
+      for (const day of dayNames) {
+        if (desc.includes(day)) {
+          closedDays.push(day);
+          break;
+        }
+      }
+      // 英語の曜日もチェック
+      const englishDays: Record<string, string> = {
+        'Monday': '月曜日',
+        'Tuesday': '火曜日',
+        'Wednesday': '水曜日',
+        'Thursday': '木曜日',
+        'Friday': '金曜日',
+        'Saturday': '土曜日',
+        'Sunday': '日曜日',
+      };
+      for (const [eng, jpn] of Object.entries(englishDays)) {
+        if (desc.includes(eng) && !closedDays.includes(jpn)) {
+          closedDays.push(jpn);
+          break;
+        }
+      }
+    }
+  }
+
+  return closedDays.length > 0 ? closedDays.join('、') : null;
+}
+
+/**
+ * 写真リファレンスから写真URLの配列を構築する
+ * Google Places API (New) の photos は name フィールドから取得
+ */
+export function buildPhotoUrls(
+  photos: PlacePhoto[] | undefined,
+  apiKey: string,
+  maxPhotos: number = 5
+): string[] {
+  if (!photos || photos.length === 0) {
+    return [];
+  }
+
+  return photos.slice(0, maxPhotos).map((photo) => {
+    // Place Photo API (New) の URL 形式
+    return `https://places.googleapis.com/v1/${photo.name}/media?maxHeightPx=800&maxWidthPx=800&key=${apiKey}`;
+  });
+}
+
+/**
+ * Google Place レビューの一意ID を生成する
+ * Review の name フィールドがない場合は著者名+公開日時からハッシュ
+ */
+export function getReviewId(review: PlaceReview): string {
+  if (review.name) {
+    return review.name;
+  }
+  // フォールバック: 著者名 + 公開日時
+  return `${review.authorAttribution.displayName}_${review.publishTime}`;
+}

--- a/scripts/scrape-google-places.ts
+++ b/scripts/scrape-google-places.ts
@@ -1,0 +1,605 @@
+/**
+ * Google Places API を使ったトリミングサロン スクレイピングスクリプト
+ *
+ * 都道府県・市区町村ごとに Text Search API で「トリミングサロン」を検索し、
+ * 取得した結果を Supabase の salons テーブルに upsert する。
+ *
+ * 使い方:
+ *   # 全都道府県スクレイピング
+ *   npx tsx --env-file=.env.local scripts/scrape-google-places.ts
+ *
+ *   # 特定都道府県のみ
+ *   npx tsx --env-file=.env.local scripts/scrape-google-places.ts --prefecture tokyo
+ *
+ *   # ドライラン（DB書き込みなし）
+ *   npx tsx --env-file=.env.local scripts/scrape-google-places.ts --dry-run
+ *
+ *   # 組み合わせ
+ *   npx tsx --env-file=.env.local scripts/scrape-google-places.ts --prefecture tokyo --dry-run
+ *
+ * 必要な環境変数(.env.local):
+ *   NEXT_PUBLIC_SUPABASE_URL      - Supabase プロジェクトURL
+ *   SUPABASE_SERVICE_ROLE_KEY     - Supabase Service Role Key (RLSバイパス)
+ *   GOOGLE_PLACES_API_KEY         - Google Places API (New) キー
+ *
+ * 環境変数の読み込みについて:
+ *   npx tsx はデフォルトでは .env.local を読み込みません。
+ *   --env-file=.env.local オプションを付けるか、
+ *   もしくは dotenv を使う場合はこのスクリプト冒頭で config() を呼んでください。
+ *
+ * Google Cloud Console での準備:
+ *   1. APIs & Services > Credentials で API キーを作成
+ *   2. APIs & Services > Library で "Places API (New)" を有効化
+ *   3. API キーを .env.local に設定:
+ *      GOOGLE_PLACES_API_KEY=your_api_key_here
+ */
+
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { config } from 'dotenv';
+import { resolve } from 'path';
+import {
+  GooglePlacesClient,
+  GooglePlace,
+  formatOpeningHours,
+  extractHolidays,
+  buildPhotoUrls,
+  getReviewId,
+  ApiQuotaExceededError,
+} from './lib/google-places';
+
+// .env.local から環境変数を読み込む（--env-file を使わない場合のフォールバック）
+config({ path: resolve(__dirname, '..', '.env.local') });
+
+// ========================================
+// 環境変数チェック
+// ========================================
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const GOOGLE_API_KEY = process.env.GOOGLE_PLACES_API_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
+  console.error('エラー: Supabase の環境変数が設定されていません。');
+  console.error('NEXT_PUBLIC_SUPABASE_URL と SUPABASE_SERVICE_ROLE_KEY を .env.local に設定してください。');
+  process.exit(1);
+}
+
+if (!GOOGLE_API_KEY) {
+  console.error('エラー: GOOGLE_PLACES_API_KEY が設定されていません。');
+  console.error('');
+  console.error('Google Cloud Console で API キーを取得してください:');
+  console.error('  1. https://console.cloud.google.com/apis/credentials で API キーを作成');
+  console.error('  2. Places API (New) を有効化');
+  console.error('  3. .env.local に追加: GOOGLE_PLACES_API_KEY=your_api_key_here');
+  process.exit(1);
+}
+
+// ========================================
+// クライアント初期化
+// ========================================
+
+const supabase: SupabaseClient = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY, {
+  auth: {
+    autoRefreshToken: false,
+    persistSession: false,
+  },
+});
+
+const placesClient = new GooglePlacesClient(GOOGLE_API_KEY, {
+  requestsPerSecond: 1,
+  maxRetries: 3,
+});
+
+// ========================================
+// コマンドライン引数解析
+// ========================================
+
+interface CliOptions {
+  prefecture?: string;   // 特定都道府県のslug（例: "tokyo"）
+  dryRun: boolean;       // DB書き込みなし
+}
+
+function parseArgs(): CliOptions {
+  const args = process.argv.slice(2);
+  const options: CliOptions = {
+    dryRun: false,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--prefecture' && i + 1 < args.length) {
+      options.prefecture = args[i + 1];
+      i++;
+    } else if (args[i] === '--dry-run') {
+      options.dryRun = true;
+    } else if (args[i] === '--help' || args[i] === '-h') {
+      console.log('使い方:');
+      console.log('  npx tsx --env-file=.env.local scripts/scrape-google-places.ts [オプション]');
+      console.log('');
+      console.log('オプション:');
+      console.log('  --prefecture <slug>  特定の都道府県のみスクレイピング (例: tokyo, osaka)');
+      console.log('  --dry-run            DB書き込みなしの確認モード');
+      console.log('  --help, -h           このヘルプを表示');
+      process.exit(0);
+    }
+  }
+
+  return options;
+}
+
+// ========================================
+// 型定義
+// ========================================
+
+interface Prefecture {
+  id: number;
+  name: string;
+  slug: string;
+  region: string;
+}
+
+interface City {
+  id: number;
+  name: string;
+  slug: string;
+  prefecture_id: number;
+}
+
+interface ScrapeStats {
+  totalSearches: number;
+  totalPlacesFound: number;
+  inserted: number;
+  updated: number;
+  skipped: number;
+  failed: number;
+  reviewsInserted: number;
+}
+
+// ========================================
+// データ取得関数
+// ========================================
+
+/**
+ * 都道府県一覧を Supabase から取得する
+ */
+async function fetchPrefectures(prefectureSlug?: string): Promise<Prefecture[]> {
+  let query = supabase.from('prefectures').select('id, name, slug, region').order('id');
+
+  if (prefectureSlug) {
+    query = query.eq('slug', prefectureSlug);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    throw new Error(`都道府県の取得に失敗: ${error.message}`);
+  }
+
+  if (!data || data.length === 0) {
+    if (prefectureSlug) {
+      throw new Error(`都道府県が見つかりません: ${prefectureSlug}`);
+    }
+    throw new Error('都道府県データが登録されていません');
+  }
+
+  return data;
+}
+
+/**
+ * 指定都道府県の市区町村一覧を取得する
+ */
+async function fetchCities(prefectureId: number): Promise<City[]> {
+  const { data, error } = await supabase
+    .from('cities')
+    .select('id, name, slug, prefecture_id')
+    .eq('prefecture_id', prefectureId)
+    .order('id');
+
+  if (error) {
+    throw new Error(`市区町村の取得に失敗: ${error.message}`);
+  }
+
+  return data || [];
+}
+
+/**
+ * 住所文字列から都道府県名を抽出して prefecture_id を推定する
+ */
+async function matchPrefectureFromAddress(
+  address: string,
+  prefecturesCache: Prefecture[]
+): Promise<number | null> {
+  for (const pref of prefecturesCache) {
+    if (address.includes(pref.name)) {
+      return pref.id;
+    }
+  }
+  return null;
+}
+
+/**
+ * 住所文字列から市区町村名を抽出して city_id を推定する
+ */
+async function matchCityFromAddress(
+  address: string,
+  prefectureId: number
+): Promise<number | null> {
+  const { data: cities } = await supabase
+    .from('cities')
+    .select('id, name')
+    .eq('prefecture_id', prefectureId);
+
+  if (!cities) return null;
+
+  for (const city of cities) {
+    if (address.includes(city.name)) {
+      return city.id;
+    }
+  }
+
+  return null;
+}
+
+// ========================================
+// Upsert ロジック
+// ========================================
+
+/**
+ * Google Place の情報を salons テーブルに upsert する
+ */
+async function upsertSalon(
+  place: GooglePlace,
+  prefectureId: number,
+  cityId: number | null,
+  allPrefectures: Prefecture[],
+  dryRun: boolean
+): Promise<'inserted' | 'updated' | 'skipped' | 'failed'> {
+  try {
+    const googlePlaceId = place.id;
+    const name = place.displayName?.text;
+    const address = place.formattedAddress;
+
+    if (!name || !address) {
+      console.warn(`    スキップ: 名前または住所が取得できませんでした`);
+      return 'skipped';
+    }
+
+    // 住所からprefecture_id/city_idを再推定（検索結果が別の都道府県の場合がある）
+    let resolvedPrefId = prefectureId;
+    let resolvedCityId = cityId;
+
+    const matchedPrefId = await matchPrefectureFromAddress(address, allPrefectures);
+    if (matchedPrefId) {
+      resolvedPrefId = matchedPrefId;
+      resolvedCityId = await matchCityFromAddress(address, resolvedPrefId);
+    }
+
+    // 営業時間
+    const businessHours = formatOpeningHours(place.regularOpeningHours);
+    const holidays = extractHolidays(place.regularOpeningHours);
+
+    // 写真URL
+    const photoUrls = buildPhotoUrls(place.photos, GOOGLE_API_KEY!, 10);
+
+    // upsert用のデータ
+    const salonData = {
+      name,
+      address,
+      lat: place.location?.latitude ?? null,
+      lng: place.location?.longitude ?? null,
+      phone: place.nationalPhoneNumber ?? null,
+      prefecture_id: resolvedPrefId,
+      city_id: resolvedCityId,
+      business_hours: businessHours,
+      holidays,
+      image_url: photoUrls.length > 0 ? photoUrls[0] : null,
+      website_url: place.websiteUri ?? null,
+      google_place_id: googlePlaceId,
+      google_rating: place.rating ?? null,
+      google_review_count: place.userRatingCount ?? 0,
+      google_photos: photoUrls,
+      last_scraped_at: new Date().toISOString(),
+    };
+
+    if (dryRun) {
+      console.log(`    [DRY RUN] upsert: ${name} (${address})`);
+      return 'inserted';
+    }
+
+    // google_place_id で既存チェック
+    const { data: existing } = await supabase
+      .from('salons')
+      .select('id')
+      .eq('google_place_id', googlePlaceId)
+      .maybeSingle();
+
+    if (existing) {
+      // UPDATE
+      const { error: updateError } = await supabase
+        .from('salons')
+        .update({
+          ...salonData,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('google_place_id', googlePlaceId);
+
+      if (updateError) {
+        console.error(`    エラー(更新): ${name} - ${updateError.message}`);
+        return 'failed';
+      }
+      return 'updated';
+    } else {
+      // INSERT
+      const { data: inserted, error: insertError } = await supabase
+        .from('salons')
+        .insert(salonData)
+        .select('id')
+        .single();
+
+      if (insertError) {
+        // 名前+住所の重複の可能性
+        if (insertError.code === '23505') {
+          console.warn(`    スキップ(重複): ${name}`);
+          return 'skipped';
+        }
+        console.error(`    エラー(挿入): ${name} - ${insertError.message}`);
+        return 'failed';
+      }
+
+      // レビューを保存
+      if (inserted && place.reviews && place.reviews.length > 0) {
+        await upsertReviews(inserted.id, place.reviews, dryRun);
+      }
+
+      return 'inserted';
+    }
+  } catch (error) {
+    console.error(`    例外: ${error}`);
+    return 'failed';
+  }
+}
+
+/**
+ * レビューを external_reviews テーブルに upsert する
+ */
+async function upsertReviews(
+  salonId: string,
+  reviews: GooglePlace['reviews'],
+  dryRun: boolean
+): Promise<number> {
+  if (!reviews || reviews.length === 0) return 0;
+
+  let count = 0;
+
+  for (const review of reviews) {
+    const sourceReviewId = getReviewId(review);
+    const rating = Math.min(5, Math.max(1, Math.round(review.rating)));
+
+    const reviewData = {
+      salon_id: salonId,
+      source: 'google' as const,
+      source_review_id: sourceReviewId,
+      author_name: review.authorAttribution?.displayName ?? '匿名',
+      author_photo_url: review.authorAttribution?.photoUri ?? null,
+      rating,
+      text: review.text?.text ?? review.originalText?.text ?? null,
+      published_at: review.publishTime ?? null,
+      language: review.text?.languageCode ?? review.originalText?.languageCode ?? 'ja',
+    };
+
+    if (dryRun) {
+      console.log(`      [DRY RUN] レビュー: ${reviewData.author_name} (${rating}点)`);
+      count++;
+      continue;
+    }
+
+    const { error } = await supabase
+      .from('external_reviews')
+      .upsert(reviewData, {
+        onConflict: 'source,source_review_id',
+      });
+
+    if (error) {
+      console.warn(`      レビュー保存エラー: ${error.message}`);
+    } else {
+      count++;
+    }
+  }
+
+  return count;
+}
+
+// ========================================
+// メイン処理
+// ========================================
+
+async function main(): Promise<void> {
+  const options = parseArgs();
+
+  console.log('========================================');
+  console.log('Google Places API トリミングサロン スクレイピング');
+  console.log('========================================');
+  if (options.dryRun) {
+    console.log('[DRY RUN モード] DB書き込みは行いません');
+  }
+  if (options.prefecture) {
+    console.log(`対象都道府県: ${options.prefecture}`);
+  }
+  console.log('');
+
+  // Ctrl+C ハンドリング
+  let interrupted = false;
+  process.on('SIGINT', () => {
+    console.log('\n\n中断されました。現在の進捗までの結果を表示します...');
+    interrupted = true;
+  });
+
+  // 統計
+  const stats: ScrapeStats = {
+    totalSearches: 0,
+    totalPlacesFound: 0,
+    inserted: 0,
+    updated: 0,
+    skipped: 0,
+    failed: 0,
+    reviewsInserted: 0,
+  };
+
+  try {
+    // 都道府県一覧を取得
+    const prefectures = await fetchPrefectures(options.prefecture);
+    const allPrefectures = options.prefecture
+      ? await fetchPrefectures()
+      : prefectures;
+
+    console.log(`対象都道府県: ${prefectures.length} 件`);
+    console.log('');
+
+    // 都道府県ループ
+    for (let prefIdx = 0; prefIdx < prefectures.length; prefIdx++) {
+      if (interrupted) break;
+
+      const prefecture = prefectures[prefIdx];
+      console.log(`[${prefIdx + 1}/${prefectures.length}] ${prefecture.name} (${prefecture.slug})`);
+
+      // 市区町村を取得
+      const cities = await fetchCities(prefecture.id);
+
+      if (cities.length === 0) {
+        // 市区町村が登録されていない場合は都道府県名で検索
+        console.log(`  市区町村データなし -> 都道府県名で検索`);
+        await searchAndUpsert(
+          `トリミングサロン ${prefecture.name}`,
+          prefecture.id,
+          null,
+          allPrefectures,
+          stats,
+          options.dryRun
+        );
+        if (interrupted) break;
+      } else {
+        // 各市区町村で検索
+        for (let cityIdx = 0; cityIdx < cities.length; cityIdx++) {
+          if (interrupted) break;
+
+          const city = cities[cityIdx];
+          console.log(`  [${cityIdx + 1}/${cities.length}] ${city.name}`);
+
+          await searchAndUpsert(
+            `トリミングサロン ${prefecture.name}${city.name}`,
+            prefecture.id,
+            city.id,
+            allPrefectures,
+            stats,
+            options.dryRun
+          );
+        }
+      }
+
+      console.log(`  -> ${prefecture.name} 完了`);
+      console.log('');
+    }
+  } catch (error) {
+    if (error instanceof ApiQuotaExceededError) {
+      console.error('');
+      console.error('=== API Quota 超過 ===');
+      console.error('Google Places API の利用制限に達しました。');
+      console.error('しばらく待ってから再実行してください。');
+      console.error('既に登録済みのデータは保持されています。');
+    } else {
+      console.error(`\n予期しないエラー: ${error}`);
+    }
+  }
+
+  // 結果サマリー
+  printSummary(stats, options.dryRun);
+}
+
+/**
+ * 検索クエリを実行し、結果を upsert する
+ */
+async function searchAndUpsert(
+  query: string,
+  prefectureId: number,
+  cityId: number | null,
+  allPrefectures: Prefecture[],
+  stats: ScrapeStats,
+  dryRun: boolean
+): Promise<void> {
+  try {
+    stats.totalSearches++;
+
+    const places = await placesClient.searchAllPlaces(query);
+
+    if (!places || places.length === 0) {
+      console.log(`    検索結果: 0 件`);
+      return;
+    }
+
+    console.log(`    検索結果: ${places.length} 件`);
+    stats.totalPlacesFound += places.length;
+
+    for (const place of places) {
+      const displayName = place.displayName?.text ?? '(名前なし)';
+      const result = await upsertSalon(place, prefectureId, cityId, allPrefectures, dryRun);
+
+      switch (result) {
+        case 'inserted':
+          stats.inserted++;
+          console.log(`    + ${displayName}`);
+          // レビュー数をカウント（insertedの場合はupsertSalon内で保存済み）
+          if (place.reviews) {
+            stats.reviewsInserted += place.reviews.length;
+          }
+          break;
+        case 'updated':
+          stats.updated++;
+          console.log(`    ~ ${displayName} (更新)`);
+          break;
+        case 'skipped':
+          stats.skipped++;
+          break;
+        case 'failed':
+          stats.failed++;
+          break;
+      }
+    }
+  } catch (error) {
+    if (error instanceof ApiQuotaExceededError) {
+      throw error; // Quota超過はメインで処理
+    }
+    console.error(`    検索エラー: ${error}`);
+    stats.failed++;
+  }
+}
+
+/**
+ * 結果サマリーを表示する
+ */
+function printSummary(stats: ScrapeStats, dryRun: boolean): void {
+  console.log('');
+  console.log('========================================');
+  console.log('スクレイピング結果サマリー');
+  if (dryRun) {
+    console.log('[DRY RUN モード]');
+  }
+  console.log('========================================');
+  console.log(`  検索回数:         ${stats.totalSearches} 回`);
+  console.log(`  検索結果合計:     ${stats.totalPlacesFound} 件`);
+  console.log('  ---');
+  console.log(`  新規登録:         ${stats.inserted} 件`);
+  console.log(`  更新:             ${stats.updated} 件`);
+  console.log(`  スキップ(重複):   ${stats.skipped} 件`);
+  console.log(`  失敗:             ${stats.failed} 件`);
+  console.log('  ---');
+  console.log(`  レビュー登録:     ${stats.reviewsInserted} 件`);
+  console.log('========================================');
+}
+
+// ========================================
+// エントリポイント
+// ========================================
+
+main().catch((err) => {
+  console.error('予期しないエラーが発生しました:', err);
+  process.exit(1);
+});

--- a/src/app/salons/[id]/page.tsx
+++ b/src/app/salons/[id]/page.tsx
@@ -19,7 +19,8 @@ import {
   Cat,
   DoorOpen,
 } from "lucide-react";
-import { getSalonById } from "@/lib/supabase/queries";
+import { getSalonById, getExternalReviews } from "@/lib/supabase/queries";
+import GoogleReviews from "@/components/GoogleReviews";
 import {
   generateSalonJsonLd,
   generateBreadcrumbJsonLd,
@@ -161,6 +162,10 @@ export default async function SalonDetailPage({ params }: Props) {
       if (data && data.length > 0) nearbySalons = data as Salon[];
     }
   }
+
+  // ---- Google reviews ----
+  const googleReviews = await getExternalReviews(salon.id);
+  const googleOnlyReviews = googleReviews.filter((r) => r.source === "google");
 
   // ---- Breadcrumb ----
   const breadcrumbItems = [
@@ -584,6 +589,14 @@ export default async function SalonDetailPage({ params }: Props) {
           </div>
         )}
       </div>
+
+      {/* ===== 7.5 Google Reviews ===== */}
+      <GoogleReviews
+        reviews={googleOnlyReviews}
+        googleRating={salon.google_rating}
+        googleReviewCount={salon.google_review_count}
+        googlePlaceId={salon.google_place_id}
+      />
 
       {/* ===== 8. FAQ ===== */}
       <div className="bg-white rounded-2xl shadow-sm p-8 mb-6">

--- a/src/components/ExpandableReviewText.tsx
+++ b/src/components/ExpandableReviewText.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+
+type Props = {
+  text: string;
+};
+
+export default function ExpandableReviewText({ text }: Props) {
+  const [expanded, setExpanded] = useState(false);
+  const [isClamped, setIsClamped] = useState(false);
+  const textRef = useRef<HTMLParagraphElement>(null);
+
+  useEffect(() => {
+    const el = textRef.current;
+    if (el) {
+      // Check if the text overflows the 3-line clamp
+      setIsClamped(el.scrollHeight > el.clientHeight);
+    }
+  }, [text]);
+
+  return (
+    <div>
+      <p
+        ref={textRef}
+        className={`text-sm text-gray-700 leading-relaxed ${
+          expanded ? "" : "line-clamp-3"
+        }`}
+      >
+        {text}
+      </p>
+      {isClamped && !expanded && (
+        <button
+          type="button"
+          onClick={() => setExpanded(true)}
+          className="text-sm text-blue-600 hover:text-blue-800 mt-1 font-medium"
+        >
+          もっと見る
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/GoogleReviews.tsx
+++ b/src/components/GoogleReviews.tsx
@@ -1,0 +1,231 @@
+import { Star, ExternalLink } from "lucide-react";
+import type { ExternalReview } from "@/lib/types/database";
+import ExpandableReviewText from "@/components/ExpandableReviewText";
+
+type Props = {
+  reviews: ExternalReview[];
+  googleRating?: number | null;
+  googleReviewCount?: number | null;
+  googlePlaceId?: string | null;
+};
+
+/* ------------------------------------------------------------------
+   Google "G" logo rendered as inline SVG (brand-compliant colours)
+   ------------------------------------------------------------------ */
+function GoogleGIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.27-4.74 3.27-8.1z"
+        fill="#4285F4"
+      />
+      <path
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+        fill="#34A853"
+      />
+      <path
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+        fill="#FBBC05"
+      />
+      <path
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+        fill="#EA4335"
+      />
+    </svg>
+  );
+}
+
+/* ------------------------------------------------------------------
+   Relative time helper  (e.g. "3ヶ月前", "1年前")
+   ------------------------------------------------------------------ */
+function relativeTime(dateStr: string): string {
+  const now = new Date();
+  const then = new Date(dateStr);
+  const diffMs = now.getTime() - then.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHour = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHour / 24);
+  const diffMonth = Math.floor(diffDay / 30);
+  const diffYear = Math.floor(diffDay / 365);
+
+  if (diffYear >= 1) return `${diffYear}年前`;
+  if (diffMonth >= 1) return `${diffMonth}ヶ月前`;
+  if (diffDay >= 7) return `${Math.floor(diffDay / 7)}週間前`;
+  if (diffDay >= 1) return `${diffDay}日前`;
+  if (diffHour >= 1) return `${diffHour}時間前`;
+  if (diffMin >= 1) return `${diffMin}分前`;
+  return "たった今";
+}
+
+/* ------------------------------------------------------------------
+   Star rating row
+   ------------------------------------------------------------------ */
+function StarRating({
+  rating,
+  size = "h-4 w-4",
+}: {
+  rating: number;
+  size?: string;
+}) {
+  return (
+    <span className="flex items-center gap-0.5">
+      {Array.from({ length: 5 }, (_, i) => (
+        <Star
+          key={i}
+          className={`${size} ${
+            i < Math.round(rating)
+              ? "fill-yellow-400 text-yellow-400"
+              : "text-gray-300"
+          }`}
+        />
+      ))}
+    </span>
+  );
+}
+
+/* ------------------------------------------------------------------
+   Author avatar (first letter fallback)
+   ------------------------------------------------------------------ */
+function AuthorAvatar({
+  name,
+  photoUrl,
+}: {
+  name: string;
+  photoUrl: string | null;
+}) {
+  const initial = name.charAt(0).toUpperCase();
+
+  if (photoUrl) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={photoUrl}
+        alt={name}
+        className="h-9 w-9 rounded-full object-cover"
+        referrerPolicy="no-referrer"
+      />
+    );
+  }
+
+  return (
+    <div className="h-9 w-9 rounded-full bg-blue-100 flex items-center justify-center text-sm font-semibold text-blue-700">
+      {initial}
+    </div>
+  );
+}
+
+/* ==================================================================
+   Main component
+   ================================================================== */
+export default function GoogleReviews({
+  reviews,
+  googleRating,
+  googleReviewCount,
+  googlePlaceId,
+}: Props) {
+  // If there are no Google reviews, render nothing
+  if (!reviews || reviews.length === 0) return null;
+
+  const googleMapsUrl = googlePlaceId
+    ? `https://www.google.com/maps/place/?q=place_id:${googlePlaceId}`
+    : null;
+
+  return (
+    <div className="bg-white rounded-2xl shadow-sm p-8 mb-6">
+      {/* ---- Header with Google attribution ---- */}
+      <div className="flex items-center justify-between flex-wrap gap-3 mb-6">
+        <h2 className="text-xl font-bold text-gray-900 flex items-center gap-2">
+          <GoogleGIcon className="h-6 w-6" />
+          Google の口コミ
+        </h2>
+
+        {googleMapsUrl && (
+          <a
+            href={googleMapsUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-sm text-blue-600 hover:text-blue-800 font-medium"
+          >
+            Google で口コミを見る
+            <ExternalLink className="h-4 w-4" />
+          </a>
+        )}
+      </div>
+
+      {/* ---- Rating summary ---- */}
+      {googleRating != null && (
+        <div className="flex items-center gap-4 mb-6 p-4 bg-gray-50 rounded-xl border border-gray-100">
+          <p className="text-4xl font-bold text-gray-800">
+            {googleRating.toFixed(1)}
+          </p>
+          <div>
+            <StarRating rating={googleRating} size="h-5 w-5" />
+            {googleReviewCount != null && (
+              <p className="text-xs text-gray-500 mt-0.5">
+                Google 上の口コミ {googleReviewCount}件
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* ---- Individual review cards ---- */}
+      <div className="space-y-5">
+        {reviews.map((review) => (
+          <div
+            key={review.id}
+            className="border-b border-gray-100 pb-5 last:border-0"
+          >
+            {/* Author row */}
+            <div className="flex items-center gap-3 mb-2">
+              <AuthorAvatar
+                name={review.author_name}
+                photoUrl={review.author_photo_url}
+              />
+              <div className="min-w-0 flex-1">
+                <p className="font-semibold text-sm text-gray-800 truncate">
+                  {review.author_name}
+                </p>
+                <div className="flex items-center gap-2">
+                  <StarRating rating={review.rating} />
+                  {review.published_at && (
+                    <span className="text-xs text-gray-400">
+                      {relativeTime(review.published_at)}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* Review text */}
+            {review.text && <ExpandableReviewText text={review.text} />}
+          </div>
+        ))}
+      </div>
+
+      {/* ---- Google attribution footer ---- */}
+      <div className="mt-6 pt-4 border-t border-gray-100 flex items-center justify-between flex-wrap gap-2">
+        <p className="text-xs text-gray-400 flex items-center gap-1.5">
+          <GoogleGIcon className="h-4 w-4" />
+          Google が提供する口コミ
+        </p>
+        {googleMapsUrl && (
+          <a
+            href={googleMapsUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-gray-400 hover:text-gray-600 flex items-center gap-1"
+          >
+            Google マップで見る
+            <ExternalLink className="h-3 w-3" />
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/supabase/queries.ts
+++ b/src/lib/supabase/queries.ts
@@ -8,6 +8,7 @@ import type {
   Feature,
   Service,
   Review,
+  ExternalReview,
   SearchParams,
 } from "@/lib/types/database";
 
@@ -304,4 +305,42 @@ export async function getSalonCountByCity(
     city_id,
     count,
   }));
+}
+
+// ========================================
+// 外部レビュー（Google口コミ等）
+// ========================================
+
+export async function getExternalReviews(salonId: string): Promise<ExternalReview[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("external_reviews")
+    .select("*")
+    .eq("salon_id", salonId)
+    .order("published_at", { ascending: false });
+  if (error) {
+    console.error("getExternalReviews error:", error.message);
+    return [];
+  }
+  return data ?? [];
+}
+
+export async function upsertSalonGoogleData(
+  salonId: string,
+  googleData: {
+    google_place_id: string;
+    google_rating: number | null;
+    google_review_count: number | null;
+    google_photos: string[];
+  }
+): Promise<void> {
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("salons")
+    .update({
+      ...googleData,
+      last_scraped_at: new Date().toISOString(),
+    })
+    .eq("id", salonId);
+  if (error) console.error("upsertSalonGoogleData error:", error.message);
 }

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -34,6 +34,11 @@ export type Salon = {
   image_url: string | null;
   website_url: string | null;
   owner_id: string | null;
+  google_place_id: string | null;
+  google_rating: number | null;
+  google_review_count: number | null;
+  google_photos: string[] | null;
+  last_scraped_at: string | null;
   created_at: string;
   updated_at: string | null;
 };
@@ -45,6 +50,7 @@ export type SalonWithRelations = Salon & {
   salon_breeds?: { dog_breeds: DogBreed }[];
   services?: Service[];
   reviews?: Review[];
+  external_reviews?: ExternalReview[];
 };
 
 export type DogBreed = {
@@ -78,6 +84,20 @@ export type Profile = {
   id: string;
   display_name: string | null;
   avatar_url: string | null;
+  created_at: string;
+};
+
+export type ExternalReview = {
+  id: number;
+  salon_id: string;
+  source: 'google' | string;
+  source_review_id: string | null;
+  author_name: string;
+  author_photo_url: string | null;
+  rating: number;
+  text: string | null;
+  published_at: string | null;
+  language: string;
   created_at: string;
 };
 

--- a/supabase/migrations/20240103000000_google_places.sql
+++ b/supabase/migrations/20240103000000_google_places.sql
@@ -1,0 +1,30 @@
+-- salons テーブルに Google Places 関連カラム追加
+ALTER TABLE salons ADD COLUMN IF NOT EXISTS google_place_id TEXT UNIQUE;
+ALTER TABLE salons ADD COLUMN IF NOT EXISTS google_rating NUMERIC(2,1);
+ALTER TABLE salons ADD COLUMN IF NOT EXISTS google_review_count INT DEFAULT 0;
+ALTER TABLE salons ADD COLUMN IF NOT EXISTS google_photos JSONB DEFAULT '[]';
+ALTER TABLE salons ADD COLUMN IF NOT EXISTS last_scraped_at TIMESTAMPTZ;
+
+-- インデックス
+CREATE INDEX IF NOT EXISTS idx_salons_google_place_id ON salons(google_place_id);
+
+-- 外部レビューテーブル（Google口コミ等を格納）
+CREATE TABLE IF NOT EXISTS external_reviews (
+  id SERIAL PRIMARY KEY,
+  salon_id UUID REFERENCES salons(id) ON DELETE CASCADE NOT NULL,
+  source TEXT NOT NULL DEFAULT 'google',
+  source_review_id TEXT,
+  author_name TEXT NOT NULL,
+  author_photo_url TEXT,
+  rating INT NOT NULL CHECK (rating >= 1 AND rating <= 5),
+  text TEXT,
+  published_at TIMESTAMPTZ,
+  language TEXT DEFAULT 'ja',
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(source, source_review_id)
+);
+
+ALTER TABLE external_reviews ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "外部レビューは全員閲覧可" ON external_reviews FOR SELECT USING (true);
+CREATE INDEX idx_external_reviews_salon ON external_reviews(salon_id);
+CREATE INDEX idx_external_reviews_source ON external_reviews(source);


### PR DESCRIPTION
## Summary
- Google Places APIを使ったトリミングサロン自動収集フロー構築
- Google口コミのDB格納 + サロン詳細ページでの表示
- 定期実行可能なスクレイピングスクリプト（`/scrape-salons` スキル）

## 変更内容

### DB拡張（マイグレーション）
- `salons` テーブルに Google Places 関連カラム追加（google_place_id, google_rating 等）
- `external_reviews` テーブル新設（RLS + インデックス設定済み）

### スクレイピングスクリプト
| スクリプト | 機能 |
|-----------|------|
| `scripts/scrape-google-places.ts` | Google Places Text SearchでサロンをDB登録 |
| `scripts/fetch-google-reviews.ts` | 既存サロンのGoogle口コミを更新 |
| `scripts/lib/google-places.ts` | APIラッパー（Rate limiting + リトライ） |

### フロントエンド
- `GoogleReviews` コンポーネント（Googleアトリビューション付き口コミ表示）
- `ExpandableReviewText` コンポーネント（長文レビューの展開/折りたたみ）
- サロン詳細ページに口コミセクション統合

## 実行に必要な準備
1. Supabase SQL Editorで `20240103000000_google_places.sql` を実行
2. `.env.local` に `GOOGLE_PLACES_API_KEY` を追加
3. Vercelの環境変数にも `GOOGLE_PLACES_API_KEY` を追加（口コミ表示に必要）

## Test plan
- [ ] `npm run build` 成功確認 ✅
- [ ] Supabaseマイグレーション適用
- [ ] `npx tsx --env-file=.env.local scripts/scrape-google-places.ts --dry-run` で動作確認
- [ ] サロン詳細ページでGoogle口コミ表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)